### PR TITLE
Delete non existing room fix

### DIFF
--- a/lib/easyrtc_public_obj.js
+++ b/lib/easyrtc_public_obj.js
@@ -2406,9 +2406,11 @@ pub.app = function(appName, callback) {
             return;
         }
 
-        // If room is already deleted or if it doesn't exist, then report success
+        // If room is already deleted or if it doesn't exist, report error
         if (!appObj.isRoomSync(roomName)) {
-            callback(null, true);
+            var errorMsg = "Can't delete non-existing room";
+            pub.util.logWarning(errorMsg);
+            callback(new pub.util.ApplicationWarning(errorMsg), false);
             return;
         }
 

--- a/lib/easyrtc_public_obj.js
+++ b/lib/easyrtc_public_obj.js
@@ -2408,7 +2408,7 @@ pub.app = function(appName, callback) {
 
         // If room is already deleted or if it doesn't exist, report error
         if (!appObj.isRoomSync(roomName)) {
-            var errorMsg = "Can't delete non-existing room";
+            var errorMsg = "Can't delete non-existing room: " + roomName;
             pub.util.logWarning(errorMsg);
             callback(new pub.util.ApplicationWarning(errorMsg), false);
             return;


### PR DESCRIPTION
See issue #81:
According to http://www.easyrtc.com/docs/server/pub.appObj.html, the second parameter of the deleteRoom callback function should return 'true' only if the room was deleted. When I delete a non-existing room, this parameter is still 'true'. I don't get an error, either.

I fixed this issue - see:  easyrtc / lib / easyrtc_public_obj.js line 2409 ff
Trying to delete a non-existing room now returns the following error msg:
"Can't delete non-existing room " + roomname

I tested the code manually.