### PR TITLE
Add mandatory third parameter to setRemoteDescription()

### DIFF
--- a/api/easyrtc.js
+++ b/api/easyrtc.js
@@ -4391,6 +4391,8 @@ var Easyrtc = function() {
                         }
                         pc.connectDataConnection(5001, 5002); // these are like ids for data channels
                     }
+                }, function(message) {
+                    self.showError(self.errCodes.INTERNAL_ERR, "set-remote-description: " + message);
                 });
             } catch (smdException) {
                 console.log("setRemoteDescription failed ", smdException);

--- a/api/easyrtc_int.js
+++ b/api/easyrtc_int.js
@@ -4208,6 +4208,8 @@ var Easyrtc = function() {
                         }
                         pc.connectDataConnection(5001, 5002); // these are like ids for data channels
                     }
+                }, function(message) {
+                    self.showError(self.errCodes.INTERNAL_ERR, "set-remote-description: " + message);
                 });
             } catch (smdException) {
                 console.log("setRemoteDescription failed ", smdException);


### PR DESCRIPTION
Hello,

here is a fix for the setRemoteConnection problem on firefox 37: the third argument has become mandatory. I used the buildEnglishVersions.sh to rebuild the easyrtc.js file.