### PR TITLE
Split long messages into chunks when using data channels

### DIFF
--- a/api/easyrtc.js
+++ b/api/easyrtc.js
@@ -1523,6 +1523,16 @@ var Easyrtc = function() {
         }
         return count;
     };
+
+    /** Sets the maximum length in bytes of P2P messages that can be sent.
+     * @param {Integer} maxLength maximum length to set
+     * @example
+     *     easyrtc.setMaxP2PMessageLength(10000);
+     */
+    this.setMaxP2PMessageLength = function(limit) {
+        this.maxP2PMessageLength = limit;
+    };
+
     /** Sets whether audio is transmitted by the local user in any subsequent calls.
      * @param {Boolean} enabled true to include audio, false to exclude audio. The default is true.
      * @example

--- a/api/easyrtc_int.js
+++ b/api/easyrtc_int.js
@@ -1340,6 +1340,16 @@ var Easyrtc = function() {
         }
         return count;
     };
+
+    /** Sets the maximum length in bytes of P2P messages that can be sent.
+     * @param {Integer} maxLength maximum length to set
+     * @example
+     *     easyrtc.setMaxP2PMessageLength(10000);
+     */
+    this.setMaxP2PMessageLength = function(limit) {
+        this.maxP2PMessageLength = limit;
+    };
+
     /** Sets whether audio is transmitted by the local user in any subsequent calls.
      * @param {Boolean} enabled true to include audio, false to exclude audio. The default is true.
      * @example

--- a/api/easyrtc_int.js
+++ b/api/easyrtc_int.js
@@ -3618,35 +3618,72 @@ var Easyrtc = function() {
                     var msg = JSON.parse(event.data);
                     if (msg) {
                         if (msg.transfer && msg.transferId) {
-                            if (msg.transfer === 'start' && msg.parts) {
+                            if (msg.transfer === 'start') {
                                 if (self.debugPrinter) {
                                     self.debugPrinter('start transfer #' + msg.transferId);
                                 }
-                                pendingTransfers[msg.transferId] = {
+
+                                var parts = parseInt(msg.parts);
+                                pendingTransfer = {
                                     chunks: [],
-                                    parts: msg.parts,
-                                }
-                            } else if (msg.transfer === 'chunk' && msg.data) {
+                                    parts: parts,
+                                    transferId: msg.transferId
+                                };
+
+                            } else if (msg.transfer === 'chunk') {
                                 if (self.debugPrinter) {
                                     self.debugPrinter('got chunk for transfer #' + msg.transferId);
                                 }
-                                pendingTransfers[msg.transferId].chunks.push(msg.data);
+
+                                // check data is valid
+                                if (!(typeof msg.data === 'string' && msg.data.length <= self.maxP2PMessageLength)) {
+                                    console.log('Developer error, invalid data');
+
+                                    // check there's a pending transfer
+                                } else if (!pendingTransfer) {
+                                    console.log('Developer error, unexpected chunk');
+
+                                // check that transferId is valid
+                                } else if (msg.transferId !== pendingTransfer.transferId) {
+                                    console.log('Developer error, invalid transfer id');
+
+                                // check that the max length of transfer is not reached
+                                } else if (pendingTransfer.chunks.length + 1 > pendingTransfer.parts) {
+                                    console.log('Developer error, received too many chunks');
+
+                                } else {
+                                    pendingTransfer.chunks.push(msg.data);
+                                }
 
                             } else if (msg.transfer === 'end') {
                                 if (self.debugPrinter) {
                                     self.debugPrinter('end of transfer #' + msg.transferId);
                                 }
-                                var pendingTransfer = pendingTransfers[msg.transferId];
 
-                                if (!pendingTransfer.chunks.length === pendingTransfer.chunks) {
-                                    console.log('Developper error, a chunk is missing');
+                                // check there's a pending transfer
+                                if (!pendingTransfer) {
+                                    console.log('Developer error, unexpected end of transfer');
+
+                                // check that transferId is valid
+                                } else if (msg.transferId !== pendingTransfer.transferId) {
+                                    console.log('Developer error, invalid transfer id');
+
+                                // check that all the chunks were received
+                                } else if (pendingTransfer.chunks.length !== pendingTransfer.parts) {
+                                    console.log('Developer error, received wrong number of chunks');
+
                                 } else {
-                                    var chunkedMsg = JSON.parse(pendingTransfer.chunks.join(''));
-                                    self.receivePeerDistribute(otherUser, chunkedMsg, null);
-                                    delete pendingTransfers[msg.transferId];
+                                    try {
+                                        var chunkedMsg = JSON.parse(pendingTransfer.chunks.join(''));
+                                        self.receivePeerDistribute(otherUser, chunkedMsg, null);
+                                    } catch (err) {
+                                        console.log('Developer error, unable to parse message');
+                                    }
                                 }
+                                pendingTransfer = {  };
+
                             } else {
-                                console.log('Developper error, got an unknown transfer message' + msg.transfer);
+                                console.log('Developer error, got an unknown transfer message' + msg.transfer);
                             }
                         } else {
                             self.receivePeerDistribute(otherUser, msg, null);

--- a/api/easyrtc_int.js
+++ b/api/easyrtc_int.js
@@ -90,6 +90,8 @@ var Easyrtc = function() {
     * The function should return one of the following: the input candidate record, a modified candidate record, or null (indicating that the
     * candidate should be discarded).
     * @param {Function} filter
+    * @param {String} isIncoming 
+    * @return an ice candidate record or null.
     */
    this.setIceCandidateFilter = function(filter) {
       iceCandidateFilter = filter;
@@ -1338,16 +1340,6 @@ var Easyrtc = function() {
         }
         return count;
     };
-
-    /** Sets the maximum length in bytes of P2P messages that can be sent.
-     * @param {Integer} maxLength maximum length to set
-     * @example
-     *     easyrtc.setMaxP2PMessageLength(10000);
-     */
-    this.setMaxP2PMessageLength = function(limit) {
-        this.maxP2PMessageLength = limit;
-    };
-
     /** Sets whether audio is transmitted by the local user in any subsequent calls.
      * @param {Boolean} enabled true to include audio, false to exclude audio. The default is true.
      * @example
@@ -3626,72 +3618,35 @@ var Easyrtc = function() {
                     var msg = JSON.parse(event.data);
                     if (msg) {
                         if (msg.transfer && msg.transferId) {
-                            if (msg.transfer === 'start') {
+                            if (msg.transfer === 'start' && msg.parts) {
                                 if (self.debugPrinter) {
                                     self.debugPrinter('start transfer #' + msg.transferId);
                                 }
-
-                                var parts = parseInt(msg.parts);
-                                pendingTransfer = {
+                                pendingTransfers[msg.transferId] = {
                                     chunks: [],
-                                    parts: parts,
-                                    transferId: msg.transferId
-                                };
-
-                            } else if (msg.transfer === 'chunk') {
+                                    parts: msg.parts,
+                                }
+                            } else if (msg.transfer === 'chunk' && msg.data) {
                                 if (self.debugPrinter) {
                                     self.debugPrinter('got chunk for transfer #' + msg.transferId);
                                 }
-
-                                // check data is valid
-                                if (!(typeof msg.data === 'string' && msg.data.length <= self.maxP2PMessageLength)) {
-                                    console.log('Developer error, invalid data');
-
-                                    // check there's a pending transfer
-                                } else if (!pendingTransfer) {
-                                    console.log('Developer error, unexpected chunk');
-
-                                // check that transferId is valid
-                                } else if (msg.transferId !== pendingTransfer.transferId) {
-                                    console.log('Developer error, invalid transfer id');
-
-                                // check that the max length of transfer is not reached
-                                } else if (pendingTransfer.chunks.length + 1 > pendingTransfer.parts) {
-                                    console.log('Developer error, received too many chunks');
-
-                                } else {
-                                    pendingTransfer.chunks.push(msg.data);
-                                }
+                                pendingTransfers[msg.transferId].chunks.push(msg.data);
 
                             } else if (msg.transfer === 'end') {
                                 if (self.debugPrinter) {
                                     self.debugPrinter('end of transfer #' + msg.transferId);
                                 }
+                                var pendingTransfer = pendingTransfers[msg.transferId];
 
-                                // check there's a pending transfer
-                                if (!pendingTransfer) {
-                                    console.log('Developer error, unexpected end of transfer');
-
-                                // check that transferId is valid
-                                } else if (msg.transferId !== pendingTransfer.transferId) {
-                                    console.log('Developer error, invalid transfer id');
-
-                                // check that all the chunks were received
-                                } else if (pendingTransfer.chunks.length !== pendingTransfer.parts) {
-                                    console.log('Developer error, received wrong number of chunks');
-
+                                if (!pendingTransfer.chunks.length === pendingTransfer.chunks) {
+                                    console.log('Developper error, a chunk is missing');
                                 } else {
-                                    try {
-                                        var chunkedMsg = JSON.parse(pendingTransfer.chunks.join(''));
-                                        self.receivePeerDistribute(otherUser, chunkedMsg, null);
-                                    } catch (err) {
-                                        console.log('Developer error, unable to parse message');
-                                    }
+                                    var chunkedMsg = JSON.parse(pendingTransfer.chunks.join(''));
+                                    self.receivePeerDistribute(otherUser, chunkedMsg, null);
+                                    delete pendingTransfers[msg.transferId];
                                 }
-                                pendingTransfer = {  };
-
                             } else {
-                                console.log('Developer error, got an unknown transfer message' + msg.transfer);
+                                console.log('Developper error, got an unknown transfer message' + msg.transfer);
                             }
                         } else {
                             self.receivePeerDistribute(otherUser, msg, null);


### PR DESCRIPTION
Hi,

as discussed in https://groups.google.com/forum/#!topic/easyrtc/T-pU35T6R-4, here is a pull request to integrate into easyrtc a way of sending arbitrary long messages.

The code is quite simple: when the flattened message is too long (currently > 1000 bytes), a message is sent using directly using the `dataChannelS.send` function. The message sent contains a field `transfer`, which indicated whether it's the beginning of the transfer, a chunk or the end of the transfer and a `transferId`, so that multiple transfers can happen at the same time.
Each message (except for the `start` and `end` messages) contains a 1000bytes long message with some extra-information (`transferId`). 

On the receiver side, when a transfer message is recognized, it starts to store in an array. Each chunk is stored until all of them arrived. When all the chunks arrived, the message if rebuilt and passed to `receivePeerDistribute`.