### PR TITLE
Use proper error variable name.

### DIFF
--- a/api/easyrtc_int.js
+++ b/api/easyrtc_int.js
@@ -4462,7 +4462,7 @@ var Easyrtc = function() {
                self.webSocket = io.connect(serverPath, connectionOptions);
             } catch(socketErr) {
                errorCallback( self.errCodes.SYSTEM_ERROR,
-                     socketError.toString());
+                     socketErr.toString());
                return;
             }
             if (!self.webSocket) {


### PR DESCRIPTION
The exception is caught as `socketErr` but it is used as `socketError`. Use correct name.