### PR TITLE
fix getUserMedia always =null issue

### DIFF
--- a/api/easyrtc.js
+++ b/api/easyrtc.js
@@ -29,6 +29,7 @@ if (navigator.mozGetUserMedia) {
     // Get UserMedia (only difference is the prefix).
     // Code from Adam Barth.
     window.getUserMedia = navigator.mozGetUserMedia.bind(navigator);
+    getUserMedia = window.getUserMedia;
     // Creates iceServer from the url for FF.
     window.createIceServer = function(url, username, password) {
         var iceServer = null;
@@ -103,6 +104,7 @@ if (navigator.mozGetUserMedia) {
     // Get UserMedia (only difference is the prefix).
     // Code from Adam Barth.
     window.getUserMedia = navigator.webkitGetUserMedia.bind(navigator);
+    getUserMedia = window.getUserMedia;
     // Attach a media stream to an element.
     attachMediaStream = function(element, stream) {
         if (typeof element.srcObject !== 'undefined') {


### PR DESCRIPTION
I used this client api in Mean.io framework. It was working fine if the script is attached directly to html. But mean.io has an aggregator where the script is wrapped into. the getUserMedia variable in line 4 is never changed since it is not associated to window.getUserMedia anymore. You will always get false when call supportsGetUserMedia()

