### PR TITLE
Fix: createOffer options no longer works!

### DIFF
--- a/api/easyrtc.js
+++ b/api/easyrtc.js
@@ -483,12 +483,7 @@ var Easyrtc = function() {
     //
     var namedLocalMediaStreams = {};
     var sessionFields = [];
-    var receivedMediaConstraints = {
-        'mandatory': {
-            'OfferToReceiveAudio': true,
-            'OfferToReceiveVideo': true
-        }
-    };
+    var receivedMediaConstraints = {"offerToReceiveAudio":true,"offerToReceiveVideo":true};
     /**
      * Control whether the client requests audio from a peer during a call.
      * Must be called before the call to have an effect.


### PR DESCRIPTION
Firefox FIX:
Mandatory/optional in createOffer options no longer works! Use {"offerToReceiveAudio":true,"offerToReceiveVideo":true} instead (note the case difference)!