### PR TITLE
fixing webrtc-adapter devDependency version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "server_example"
   ],
   "devDependencies": {
-    "webrtc-adapter": "4.1.1",
+    "webrtc-adapter": "^5.0.6",
     "jasmine": "~2.2.1",
     "requirejs": "~2.1.16"
   },


### PR DESCRIPTION
The devDependency version of the webrtc-adapter was not updated.

Fixed.