### PR TITLE
Fix #364

### DIFF
--- a/api/easyrtc.js
+++ b/api/easyrtc.js
@@ -10129,6 +10129,7 @@ var Easyrtc = function() {
                 self.showError(self.errCodes.CONNECT_ERR, self.getConstantString("badsocket"));
             }
             self.webSocketConnected = true;
+            missedAliveResponses = 0;
 
             logDebug("saw socket-server onconnect event");
 

--- a/api/easyrtc_int.js
+++ b/api/easyrtc_int.js
@@ -5617,6 +5617,7 @@ var Easyrtc = function() {
                 self.showError(self.errCodes.CONNECT_ERR, self.getConstantString("badsocket"));
             }
             self.webSocketConnected = true;
+            missedAliveResponses = 0;
 
             logDebug("saw socket-server onconnect event");
 


### PR DESCRIPTION
#364 reset missedAliveResponses to 0 when self.webSocket.on("connect", ...) to allow reconnect after network problems