### PR TITLE
Notify about ghost connection is terminated

### DIFF
--- a/lib/easyrtc_default_event_listeners.js
+++ b/lib/easyrtc_default_event_listeners.js
@@ -72,7 +72,6 @@ eventListener.startStillAliveTimer = function(connectionObj) {
        pub.events.emit("disconnect", connectionObj, function(err) {
            if(err) {pub.util.logError("["+appName+"]["+easyrtcid+"] Unhandled disconnect listener error.", err);}
        });
-      eventListener.onDisconnect(connectionObj, function(retval){});   
    }, stillAliveGracePeriod);
 }
 

--- a/lib/easyrtc_default_event_listeners.js
+++ b/lib/easyrtc_default_event_listeners.js
@@ -69,6 +69,9 @@ eventListener.startStillAliveTimer = function(connectionObj) {
    //
    connectionObj.stillAliveTimer = setTimeout( function() {
       console.log("Missed StillAliveTimer, fired disconnect");
+       pub.events.emit("disconnect", connectionObj, function(err) {
+           if(err) {pub.util.logError("["+appName+"]["+easyrtcid+"] Unhandled disconnect listener error.", err);}
+       });
       eventListener.onDisconnect(connectionObj, function(retval){});   
    }, stillAliveGracePeriod);
 }


### PR DESCRIPTION
Right now it's impossible to know about if the system GC the ghost connections (for example if the client went to airplane mode or disconnected from wifi we collect these connections).

I've added an event where we notify as a normal `disconnect` call that can be listened from outside and clean up custom business logic code.