### PR TITLE
Deprecation of URL.createObjectURL and replacement with HTMLMediaElement.srcObject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,7 +170,6 @@ pip-log.txt
 # Node.js
 #########
 node_modules
-.git
 
 #########
 # EasyRTC

--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,7 @@ pip-log.txt
 # Node.js
 #########
 node_modules
+.git
 
 #########
 # EasyRTC

--- a/api/easyrtc.js
+++ b/api/easyrtc.js
@@ -7066,7 +7066,8 @@ var Easyrtc = function() {
     this.createObjectURL = function(mediaStream) {
         var errMessage;
         if (window.URL && window.URL.createObjectURL) {
-            return window.URL.createObjectURL(mediaStream);
+            //return window.URL.createObjectURL(mediaStream);
+          return mediaStream;
         }
         else if (window.webkitURL && window.webkitURL.createObjectURL) {
             return window.webkit.createObjectURL(mediaStream);

--- a/api/easyrtc.js
+++ b/api/easyrtc.js
@@ -2580,7 +2580,7 @@ SDPUtils.getKind = function(mediaSection) {
 };
 
 SDPUtils.isRejected = function(mediaSection) {
-  return mediaSection.split(' ', 2)[1] === '0';
+  Fection.split(' ', 2)[1] === '0';
 };
 
 SDPUtils.parseMLine = function(mediaSection) {
@@ -7078,8 +7078,7 @@ var Easyrtc = function() {
     this.createObjectURL = function(mediaStream) {
         var errMessage;
         if (window.URL && window.URL.createObjectURL) {
-            //return window.URL.createObjectURL(mediaStream);
-          return mediaStream;
+          return window.URL.createObjectURL(mediaStream);
         }
         else if (window.webkitURL && window.webkitURL.createObjectURL) {
             return window.webkit.createObjectURL(mediaStream);

--- a/api/easyrtc.js
+++ b/api/easyrtc.js
@@ -3180,20 +3180,32 @@ module.exports = {
               this.src = '';
               return undefined;
             }
-            this.src = URL.createObjectURL(stream);
+            try {
+              this.srcObject = stream;
+            } catch (error) {
+              this.src = URL.createObjectURL(stream);
+            }
             // We need to recreate the blob url when a track is added or
             // removed. Doing it manually since we want to avoid a recursion.
             stream.addEventListener('addtrack', function() {
               if (self.src) {
                 URL.revokeObjectURL(self.src);
               }
-              self.src = URL.createObjectURL(stream);
+              try {
+                self.srcObject = stream;
+              } catch (error) {
+                self.src = URL.createObjectURL(stream);
+              }
             });
             stream.addEventListener('removetrack', function() {
               if (self.src) {
                 URL.revokeObjectURL(self.src);
               }
-              self.src = URL.createObjectURL(stream);
+              try {
+                self.srcObject = stream;
+              } catch (error) {
+                self.src = URL.createObjectURL(stream);
+              }
             });
           }
         });
@@ -7553,7 +7565,11 @@ var Easyrtc = function() {
             if (typeof element.srcObject !== 'undefined') {
                 element.srcObject = stream;
             } else if (typeof element.src !== 'undefined') {
-                element.src = self.createObjectURL(stream);
+                try {
+                    element.srcObject = stream;
+                } catch (error) {
+                    element.src = self.createObjectURL(stream);
+                }
             } else if (typeof element.mozSrcObject !== 'undefined') {
                 element.mozSrcObject = self.createObjectURL(stream);
             }

--- a/api/easyrtc.js
+++ b/api/easyrtc.js
@@ -2580,7 +2580,7 @@ SDPUtils.getKind = function(mediaSection) {
 };
 
 SDPUtils.isRejected = function(mediaSection) {
-  Fection.split(' ', 2)[1] === '0';
+  return mediaSection.split(' ', 2)[1] === '0';
 };
 
 SDPUtils.parseMLine = function(mediaSection) {
@@ -7078,7 +7078,7 @@ var Easyrtc = function() {
     this.createObjectURL = function(mediaStream) {
         var errMessage;
         if (window.URL && window.URL.createObjectURL) {
-          return window.URL.createObjectURL(mediaStream);
+            return window.URL.createObjectURL(mediaStream);
         }
         else if (window.webkitURL && window.webkitURL.createObjectURL) {
             return window.webkit.createObjectURL(mediaStream);
@@ -7564,11 +7564,7 @@ var Easyrtc = function() {
             if (typeof element.srcObject !== 'undefined') {
                 element.srcObject = stream;
             } else if (typeof element.src !== 'undefined') {
-                try {
-                    element.srcObject = stream;
-                } catch (error) {
-                    element.src = self.createObjectURL(stream);
-                }
+                element.src = self.createObjectURL(stream);
             } else if (typeof element.mozSrcObject !== 'undefined') {
                 element.mozSrcObject = self.createObjectURL(stream);
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1871,12 +1871,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1891,17 +1893,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2018,7 +2023,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2030,6 +2036,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2044,6 +2051,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2051,12 +2059,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2075,6 +2085,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2155,7 +2166,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2167,6 +2179,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2288,6 +2301,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
Corrected the error at the deprecated method **URL.createObjectURL(stream)**, thrown by latest versions of Google Chrome and Mozilla Firefox. Key usages have been replaced by a try-catch block with the new **HTMLMediaElement.srcObject(stream)**.